### PR TITLE
Feature/game server ver 2020

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,9 @@
+FROM hashman/apache2-php-fpm:7.2-1.0.0
+RUN apt update && apt install -y --no-install-recommends \
+  libfreetype6-dev \
+  libjpeg62-turbo-dev \
+  libpng-dev \
+  && docker-php-ext-install -j$(nproc) iconv \
+  && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+  && docker-php-ext-install -j$(nproc) gd \
+  && rm -r /var/lib/apt/lists/*

--- a/app/Http/Controllers/RewardController.php
+++ b/app/Http/Controllers/RewardController.php
@@ -21,7 +21,9 @@ class RewardController extends Controller
         $user = $this->guard()->user();
         $achievement = $user->achievement;
         $wonReward = collect($achievement[User::WON_REWARD]);
-        if ($wonReward->count() > 0) {
+        $rewardNum = intval($user->scores->sum('pass') / 6);
+        $rewardCanGet = $rewardNum - $wonReward->count();
+        if ($wonReward->count() > 1 || $rewardCanGet < 1) {
             return $this->returnSuccess('No More Reward.');
         }
 

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -15,37 +15,53 @@ class TaskController extends Controller
     use AuthTrait;
 
     /**
-     * @param string $missionUid
      * @return \Illuminate\Http\JsonResponse
      */
-    public function getTask(string $missionUid)
+    public function getTask()
     {
         $user = $this->guard()->user();
-        $last_mission_uid = env('LAST_MISSION_UID', '');
-        $last_task_id = env('LAST_TASK_ID', 0);
-        $mission = Mission::where([['uid', $missionUid], ['open', 1]])->firstOrFail();
+        $scoreBoard = Scoreboard::where('user_id', $user->id)
+            ->with(array('mission' => function ($query) {
+                $query->where('open', 1);
+            }))->get();
+        if ($scoreBoard->isEmpty()) {
+            $insertTask = [];
+            Mission::where('open', 1)
+                ->with('task')->orderby('order')
+                ->each(function ($mission) use ($user, &$insertTask) {
+                    $insertTask[] = [
+                        'user_id' => $user->id,
+                        'mission_id' => $mission->id,
+                        'task_id' => $mission->task->id,
+                    ];
+                });
+            Scoreboard::insert($insertTask);
+            $scoreBoard->fresh();
+        }
+        $missions = [];
+        $scoreBoard->each(function ($scoreData) use (&$missions) {
+            $missions[] = [
+                'uid' => $scoreData->mission->uid,
+                'name' => $scoreData->mission->name,
+                'name_e' => $scoreData->mission->name_e,
+                'description' => $scoreData->mission->description,
+                'description_e' => $scoreData->mission->description_e,
+                'order' => $scoreData->mission->order,
+                'passed' => $scoreData->pass === 1,
+            ];
+        });
 
-        if ($missionUid == $last_mission_uid) {
-            $task = Task::findOrFail($last_task_id);
-        } else {
-            $scores = $user->scores()->get();
+        $passCount = $scoreBoard->sum('pass');
+        $taskCount = $scoreBoard->count();
 
-            $existTask = $scores->where('mission_id', $mission->id);
-            if (! $existTask->isEmpty()) {
-                return $this->returnSuccess(
-                    'Success.',
-                    Task::find($existTask->first()->task_id)
-                );
-            }
+        $output = [
+            'missions' => $missions,
+            'passed' => $passCount,
+            'total' => $taskCount,
+        ];
 
-            $attendTaskIds = $scores->map(function ($item) {
-                return $item->task_id;
-            });
-            $attendTaskIds->push($last_task_id);
 
-            $task = Task::whereNotIn('id', $attendTaskIds->all())
-                ->inRandomOrder()
-                ->first();
+        return $this->returnSuccess('Success.', $output);
         }
 
         Scoreboard::create([

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -7,6 +7,7 @@ use App\Task;
 use App\Scoreboard;
 use App\Http\Traits\ApiTrait;
 use App\Http\Traits\AuthTrait;
+use App\User;
 use Illuminate\Http\Request;
 
 class TaskController extends Controller
@@ -54,10 +55,16 @@ class TaskController extends Controller
         $passCount = $scoreBoard->sum('pass');
         $taskCount = $scoreBoard->count();
 
+        $rewardInfo = [
+            'count' => intval($passCount / 6),
+            'exchanged' => collect($user->achievement[User::WON_REWARD])->count(),
+        ];
+
         $output = [
             'missions' => $missions,
             'passed' => $passCount,
             'total' => $taskCount,
+            'rewardInfo' => $rewardInfo,
         ];
 
 

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -62,14 +62,15 @@ class TaskController extends Controller
 
 
         return $this->returnSuccess('Success.', $output);
-        }
+    }
 
-        Scoreboard::create([
-            'user_id' => $user->id,
-            'mission_id' => $mission->id,
-            'task_id' => $task->id,
-        ]);
-
+    /**
+     * @param string $missionUid
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getTaskByMission(string $missionUid)
+    {
+        $task = Task::where('mission_uid', $missionUid)->firstOrFail();
         return $this->returnSuccess('Success.', $task);
     }
 

--- a/app/Mission.php
+++ b/app/Mission.php
@@ -37,4 +37,14 @@ class Mission extends Model
             $model->uid = Str::uuid();
         });
     }
+
+    public function task()
+    {
+        return $this->hasOne('App\Task', 'mission_uid', 'uid');
+    }
+
+    public function scores()
+    {
+        return $this->hasMany('App\Scoreboard', 'id', 'mission');
+    }
 }

--- a/app/Scoreboard.php
+++ b/app/Scoreboard.php
@@ -20,4 +20,14 @@ class Scoreboard extends Model
         'pass',
         'point',
     ];
+
+    public function mission()
+    {
+        return $this->belongsTo('App\Mission');
+    }
+
+    public function task()
+    {
+        return $this->belongsTo('App\Task');
+    }
 }

--- a/app/Task.php
+++ b/app/Task.php
@@ -16,6 +16,7 @@ class Task extends Model
      */
     protected $fillable = [
         'uid',
+        'mission',
         'vkey_id',
         'name',
         'name_e',
@@ -42,5 +43,15 @@ class Task extends Model
     public function KeyPool()
     {
         return $this->belongsTo('App\KeyPool', 'vkey_id', 'id');
+    }
+
+    public function mission()
+    {
+        return $this->belongsTo('App\Mission', 'mission_uid', 'uid');
+    }
+
+    public function scores()
+    {
+        return $this->hasMany('App\Scoreboard', 'id', 'task');
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -89,28 +89,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
     public function getMissionListAttribute()
     {
-        $missions = Mission::all();
-        $completed_task = collect($this->achievement[self::COMPLETED_TASK])
-            ->mapWithKeys(function ($item) {
-                return [$item['mission_id'] => $item['task_id']];
-            })->all();
-
-        $tasks = Task::findOrFail(array_values($completed_task))
-            ->mapWithKeys(function ($item) {
-                return [$item->id => $item];
-            })->toArray();
-
-        return $missions->map(function ($item) use ($tasks, $completed_task) {
-            if (array_key_exists($item->id, $completed_task)) {
-                $item->pass = 1;
-                $item->task = $tasks[$completed_task[$item->id]];
-            } else {
-                $item->pass = 0;
-                $item->task = null;
-            }
-
-            return $item;
-        });
+        $missions = Mission::with('task')->get();
+        return $missions;
     }
 
     public function getRewardListAttribute()

--- a/database/migrations/2020_09_18_172858_add_mission_field_for_task.php
+++ b/database/migrations/2020_09_18_172858_add_mission_field_for_task.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddMissionFieldForTask extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->uuid('mission_uid')->nullable()->after('uid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn('mission_uid');
+        });
+    }
+}

--- a/database/migrations/2020_09_22_170408_add_order_field_to_mission.php
+++ b/database/migrations/2020_09_22_170408_add_order_field_to_mission.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddOrderFieldToMission extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('missions', function (Blueprint $table) {
+            $table->integer('order')->default(1)->after('point');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('missions', function (Blueprint $table) {
+            $table->dropColumn('order');
+        });
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -13,7 +13,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(UsersTableSeeder::class);
         $this->call(MissionsTableSeeder::class);
-        $this->call(TasksTableSeeder::class);
         $this->call(RewardsTableSeeder::class);
         $this->call(KeyPoolTableSeeder::class);
     }

--- a/database/seeds/MissionsTableSeeder.php
+++ b/database/seeds/MissionsTableSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Mission;
+use App\Task;
 use Illuminate\Database\Seeder;
 
 class MissionsTableSeeder extends Seeder
@@ -16,7 +17,7 @@ class MissionsTableSeeder extends Seeder
         $en_faker = Faker\Factory::create('en_US');
         $item_count = 0;
 
-        while ($item_count < 8) {
+        while ($item_count < 12) {
             $data = [
                 'name' => sprintf("關卡 %s", $item_count + 1),
                 'name_e' => sprintf("Mission %s", $item_count + 1),
@@ -25,8 +26,17 @@ class MissionsTableSeeder extends Seeder
                 'open' => 1,
             ];
 
-            Mission::create($data);
+            $mission = Mission::create($data);
 
+            $task_data = [
+                'name' => sprintf("任務 %s", $item_count + 1),
+                'name_e' => sprintf("Task %s", $item_count + 1),
+                'description' => $faker->realtext(20),
+                'description_e' => $en_faker->text,
+                'image' => $faker->imageUrl('640', '480', 'technics', true, 'Faker'),
+                'mission_uid' => $mission->uid,
+            ];
+            Task::create($task_data);
             $item_count++;
         }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.4'
+services:
+  game_server:
+    build: 
+      context: ./
+      dockerfile: Dockerfile.backend
+    ports:
+      - 8080:80
+    environment:
+      APP_NAME: MopconGameServer
+      APP_ENV: local
+      APP_KEY: base64:/0wMmMiuIQeu2J/gKa5jaXXR5Gj83JSCJHjt+kqed7Q=
+      APP_DEBUG: 'true'
+      APP_URL: http://localhost:8080
+      APP_LOCALE: zh_TW
+      APP_TIMEZONE: Asia/Taipei
+      ADMIN_KEY: gametest
+      DB_CONNECTION: mysql
+      DB_HOST: game_db
+      DB_PORT: 3306
+      DB_DATABASE: mopcon_gameserver
+      DB_USERNAME: mopcon_gameserver
+      DB_PASSWORD: 123456
+      JWT_SECRET: RTRSsvVnnOXBCY2nMjyuudVlEzWDhczr9h76W63Mz2xQmOvD1krIQh6yCMuHyNq0
+    depends_on: 
+      - game_db
+    volumes:
+      - ./:/code
+
+  game_db:
+    image: mysql:5
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_DATABASE: mopcon_gameserver
+      MYSQL_USER: mopcon_gameserver
+      MYSQL_PASSWORD: 123456
+    ports:
+      - 3306:3306
+
+  game_admin:
+    image: phpmyadmin:5.0.2
+    environment:
+      PMA_HOST: game_db
+      PMA_PORT: 3306
+      PMA_USER: mopcon_gameserver
+      PMA_PASSWORD: 123456
+    ports:
+      - 8081:80

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,7 +31,8 @@ $router->group(['middleware' => 'auth:api'], function ($router) {
     });
 
     $router->get('/me', 'AuthController@me');
-    $router->get('/getTask/{missionUid}', 'TaskController@getTask');
+    $router->get('/getTask', 'TaskController@getTask');
+    $router->get('/getTask/{missionUid}', 'TaskController@getTaskByMission');
     $router->get('/getReward', 'RewardController@getReward');
     $router->post('/verify/{vType}', 'VerifyController@verify');
     $router->get('/mySession', 'UserController@getMySession');


### PR DESCRIPTION
[API doc](https://app.swaggerhub.com/apis/FWcloud916/game-server/2.0.0)

# 主要流程變動
- 每個人的關卡任務都一樣
- 每過六關可領一次獎勵
- 沒有破關順序限制

# API Diff
## 新增

1. `/getTask`

    - 取得所有任務列表 ，第一次取得時會同步建立 scoreboard 
    - scoreboard 為一次為所有任務建立

## 修改

1 . `/getTask/{missionUid}`
   - 回傳任務詳細內容

2. `/getReward`
   - 調整取得獎勵條件：
       1. 通過六關可取得一次，通過十二關取得第二次
       2. 最多取得兩次

# schema diff
## 新增
- scoreboard : 新增 `pass` 欄位，紀錄是否已通關 並 建立 task , mission 的 relation
- tasks : 新增 `mission_uid` 欄位 並 建立  mission 的 relation，每個任務綁定一個關卡

## seeder
- 將 tasks 的 seeder 放在 mission 中一起建立
