### PR TITLE
修正 KeyPool 不存在時，驗證答案會噴 exception 的問題

### DIFF
--- a/app/Http/Controllers/VerifyController.php
+++ b/app/Http/Controllers/VerifyController.php
@@ -162,6 +162,11 @@ class VerifyController extends Controller
         $check_timestamp = ($input_type == 'qrcode');
 
         $question = Question::where('uid', $uid)->firstOrFail();
+
+        if ($question->KeyPool == null) {
+            return true;
+        }
+
         $vkey = $question->KeyPool->key;
 
         if ($check_timestamp) {


### PR DESCRIPTION
針對 `Question` 如果其 `vkey_id` 對應不到 `KeyPool` 時， bypass 驗證，直接認定通關 (用於獎勵關卡)